### PR TITLE
chore(github): add backend code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request a review from the Backend team for every pull request.
+* @parcelLab/backend


### PR DESCRIPTION
Better to have it, we don't get notifications about PRs in this repo.